### PR TITLE
added support JtoolTip

### DIFF
--- a/src/MaterialUISwingDemo.java
+++ b/src/MaterialUISwingDemo.java
@@ -2,38 +2,14 @@ import mdlaf.MaterialLookAndFeel;
 import mdlaf.animation.MaterialUIMovement;
 import mdlaf.resources.MaterialColors;
 
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JCheckBoxMenuItem;
-import javax.swing.JComboBox;
-import javax.swing.JEditorPane;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPasswordField;
-import javax.swing.JProgressBar;
-import javax.swing.JRadioButton;
-import javax.swing.JRadioButtonMenuItem;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTabbedPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.JTextPane;
-import javax.swing.JToggleButton;
-import javax.swing.JToolBar;
-import javax.swing.JTree;
-import javax.swing.SpinnerListModel;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.*;
+import javax.swing.event.ListDataListener;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MaterialUISwingDemo {
 
@@ -112,6 +88,25 @@ public class MaterialUISwingDemo {
 
 		JToolBar tb = new JToolBar ("toolbar");
 		JButton button1 = new JButton ("f");
+		class ActionTest extends AbstractAction{
+
+			public ActionTest(){
+				putValue(Action.NAME, "f");
+				putValue(Action.SHORT_DESCRIPTION, "Test tool tip");
+			}
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				JDialog dialog = new JDialog();
+				JPanel jPanel = new JPanel();
+				jPanel.add(new JColorChooser());
+				dialog.setContentPane(jPanel);
+				dialog.setLocationRelativeTo(null);
+				dialog.setVisible(true);
+				dialog.pack();
+			}
+		}
+		button1.setAction(new ActionTest());
 		JButton button2 = new JButton ("e");
 		button1.setBackground (MaterialColors.LIGHT_BLUE_400);
 		button1.setForeground (Color.WHITE);

--- a/src/mdlaf/MaterialLookAndFeel.java
+++ b/src/mdlaf/MaterialLookAndFeel.java
@@ -3,6 +3,7 @@ package mdlaf;
 import mdlaf.components.button.MaterialButtonUI;
 import mdlaf.components.checkbox.MaterialCheckBoxUI;
 import mdlaf.components.checkboxmenuitem.MaterialCheckBoxMenuItemUI;
+import mdlaf.components.colorchooser.MaterialColorChooserUI;
 import mdlaf.components.combobox.MaterialComboBoxUI;
 import mdlaf.components.filechooser.MaterialFileChooserUI;
 import mdlaf.components.label.MaterialLabelUI;
@@ -26,6 +27,7 @@ import mdlaf.components.textfield.MaterialTextFieldUI;
 import mdlaf.components.textpane.MaterialTextPaneUI;
 import mdlaf.components.togglebutton.MaterialToggleButtonUI;
 import mdlaf.components.toolbar.MaterialToolBarUI;
+import mdlaf.components.tooltip.MaterialToolTipUI;
 import mdlaf.components.tree.MaterialTreeUI;
 import mdlaf.resources.MaterialBorders;
 import mdlaf.resources.MaterialColors;
@@ -69,6 +71,8 @@ public class MaterialLookAndFeel extends MetalLookAndFeel {
 	private static final String editorPane = MaterialTextPaneUI.class.getCanonicalName ();
 	private static final String separatorUI = MaterialSeparatorUI.class.getCanonicalName ();
 	private static final String fileChooserUI = MaterialFileChooserUI.class.getCanonicalName ();
+	private static final String toolTipUI = MaterialToolTipUI.class.getCanonicalName();
+	private static final String colorChooser = MaterialColorChooserUI.class.getCanonicalName();
 
 	@Override
 	public String getName () {
@@ -126,6 +130,8 @@ public class MaterialLookAndFeel extends MetalLookAndFeel {
 		table.put ("EditorPaneUI", editorPane);
 		table.put ("SeparatorUI", separatorUI);
 		table.put ("FileChooserUI", fileChooserUI);
+		table.put ("ToolTipUI", toolTipUI);
+		table.put ("ColorChooserUI", colorChooser);
 	}
 
 	@Override
@@ -309,5 +315,12 @@ public class MaterialLookAndFeel extends MetalLookAndFeel {
 
 		table.put ("Separator.background", MaterialColors.GRAY_300);
 		table.put ("Separator.foreground", MaterialColors.GRAY_300);
+
+		table.put("ToolTip.background", MaterialColors.GRAY_500);
+		table.put("ToolTip.foreground", MaterialColors.GRAY_50);
+		table.put("ToolTip.border", BorderFactory.createEmptyBorder(5,5,5,5));
+
+		table.put("ColorChooser.background ", MaterialColors.WHITE);
+		table.put("ColorChooser.foreground ", MaterialColors.BLACK);
 	}
 }

--- a/src/mdlaf/components/tooltip/MaterialToolTipUI.java
+++ b/src/mdlaf/components/tooltip/MaterialToolTipUI.java
@@ -1,0 +1,25 @@
+package mdlaf.components.tooltip;
+
+import mdlaf.resources.MaterialDrawingUtils;
+
+import javax.swing.*;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicToolTipUI;
+import java.awt.*;
+
+public class MaterialToolTipUI extends BasicToolTipUI {
+
+    public static ComponentUI createUI(JComponent c){
+        return new MaterialToolTipUI();
+    }
+
+    @Override
+    public void installUI(JComponent c) {
+        super.installUI(c);
+    }
+
+    @Override
+    public void paint(Graphics g, JComponent c) {
+        super.paint(MaterialDrawingUtils.getAliasedGraphics(g), c);
+    }
+}


### PR DESCRIPTION
I tried to add support for jColorChooser but there was no need.

I kept this appearance for the tool tip
![tooltipmaterial](https://user-images.githubusercontent.com/17150045/44235641-80125f00-a1aa-11e8-92d2-3616423f5d4e.png)