### PR TITLE
Proper maven pom.xml with site.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,233 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>io.github.vincenzopalazzo</groupId>
-  <artifactId>material-ui-swing</artifactId>
-  <version>1.1.1-rc2</version>
-  <inceptionYear>2020</inceptionYear>
-  <licenses>
-    <license>
-      <name>MIT</name>
-      <url>https://github.com/vincenzopalazzo/material-ui-swing/blob/masternow/LICENSE</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.vincenzopalazzo</groupId>
+    <artifactId>material-ui-swing</artifactId>
+    <version>1.1.1-SNAPSHOT</version>
+
+    <name>Material UI Swing</name>
+    <description>Material UI Look &amp; Feel for Java Swing UI Toolkit</description>
+
+    <url>https://github.com/vincenzopalazzo/material-ui-swing</url>
+    <inceptionYear>2016</inceptionYear>
+
+    <mailingLists>
+        <mailingList>
+            <name>Material UI Swing on Gitter</name>
+            <post>https://gitter.im/material-ui-swing</post>
+        </mailingList>
+    </mailingLists>
+
+    <developers>
+        <developer>
+            <id>atarw</id>
+            <name>Atharva Washimkar</name>
+            <url>https://github.com/atarw</url>
+        </developer>
+        <developer>
+            <id>vincenzopalazzo</id>
+            <name>Vincenzo Palazzo</name>
+            <url>https://github.com/vincenzopalazzo</url>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://github.com/vincenzopalazzo/material-ui-swing/blob/masternow/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/vincenzopalazzo/material-ui-swing/issues</url>
+    </issueManagement>
+
+    <ciManagement>
+        <system>GitHub Actions</system>
+        <url>https://github.com/vincenzopalazzo/material-ui-swing/actions</url>
+    </ciManagement>
+
+    <scm>
+        <connection>scm:git:https://github.com/vincenzopalazzo/material-ui-swing.git</connection>
+        <developerConnection>scm:git:https://github.com/vincenzopalazzo/material-ui-swing.git</developerConnection>
+        <url>https://github.com/vincenzopalazzo/material-ui-swing</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <java.release>1.8</java.release>
+    </properties>
+
+    <dependencies>
+        <!-- SwingX -->
+        <dependency>
+            <groupId>org.swinglabs</groupId>
+            <artifactId>swingx</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
+        <!-- Icons -->
+        <dependency>
+            <groupId>com.github.jiconfont</groupId>
+            <artifactId>jiconfont-bundle</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jiconfont</groupId>
+            <artifactId>jiconfont-swing</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-swing-junit</artifactId>
+            <version>3.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.release}</source>
+                    <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-Xlint:deprecation</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>mdlaf</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.doxia</groupId>
+                        <artifactId>doxia-module-markdown</artifactId>
+                        <version>1.8</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <detectJavaApiLink>true</detectJavaApiLink>
+                            <doclint>none</doclint>
+                            <quiet>true</quiet>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>2.5.3</version>
+                        <configuration>
+                            <tagNameFormat>v@{project.version}</tagNameFormat>
+                            <developmentVersion>HEAD-SNAPSHOT</developmentVersion>
+                            <pushChanges>false</pushChanges>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd">
+
+    <version position="right" />
+
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.9</version>
+    </skin>
+
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+            <item name="Dev Wiki" href="https://github.com/vincenzopalazzo/material-ui-swing/wiki" />
+            <item name="Javadoc" href="https://vincenzopalazzo.github.io/material-ui-swing/" />
+            <item name="Download" href="https://github.com/vincenzopalazzo/material-ui-swing/releases" />
+        </menu>
+        <menu name="Demos">
+            <item name="Basic" href="https://github.com/vincenzopalazzo/material-ui-swing/tree/development/demos" />
+        </menu>
+        <menu ref="reports" />
+    </body>
+</project>


### PR DESCRIPTION
As we discussed in https://github.com/atarw/material-ui-swing/issues/107 I'm providing proper pom for publishing in central (with JPMS manifest attribute).

It happens to work so I also included useful information and plugins related to release (source and javadoc jars)

Because current [site](https://vincenzopalazzo.github.io/material-ui-swing/) points directly to javadoc I also included basic site.xml file which allows to generate a nice project site (with `mvn site`)

@vincenzopalazzo please review.