### PR TITLE
Build regular and all-deps jar when running jar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,15 +53,30 @@ allprojects {
 }
 
 jar {
-    archiveBaseName = project.name + '-' + VERSION
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
+	archiveVersion = VERSION
+
 	inputs.property("moduleName", MODULE_NAME)
 
 	manifest {
 		attributes  'Automatic-Module-Name': MODULE_NAME
 	}
+
+}
+
+task jarAllDeps(type: Jar) {
+	archiveVersion = VERSION
+	archiveClassifier = 'all-deps'
+
+	from {
+		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+	}
+	with jar
+}
+
+jar.finalizedBy(jarAllDeps)
+
+artifacts {
+	archives jarAllDeps
 }
 
 uploadArchives.onlyIf { property('RELEASE_ENABLE') == 'true' }


### PR DESCRIPTION
Hi @vincenzopalazzo

This PR makes it possible to build both simple and all deps jars during regular build.

When publishing both of them will be uploaded.

IMHO this is not a breaking change since the pom file for the artifact in Maven Central already contained information about dependencies so the ones included in the jar as class files where not needed. A line in release notes would be nice.

When it comes to the artifacts published on release page here on GitHub I think it would sensible to include both.