### PR TITLE
Add anti aliasing rendering hints regardless of system default

### DIFF
--- a/src/main/java/mdlaf/components/menu/MaterialMenuUI.java
+++ b/src/main/java/mdlaf/components/menu/MaterialMenuUI.java
@@ -27,6 +27,9 @@ import javax.swing.*;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicMenuUI;
+
+import mdlaf.utils.MaterialDrawingUtils;
+
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -65,7 +68,7 @@ public class MaterialMenuUI extends BasicMenuUI {
 
 	@Override
 	public void paint (Graphics g, JComponent c) {
-		super.paint (g, c);
+		super.paint (MaterialDrawingUtils.getAliasedGraphics (g), c);
 	}
 
 	@Override

--- a/src/main/java/mdlaf/components/textfield/MaterialComponentField.java
+++ b/src/main/java/mdlaf/components/textfield/MaterialComponentField.java
@@ -27,6 +27,9 @@ package mdlaf.components.textfield;
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicTextFieldUI;
 import javax.swing.text.JTextComponent;
+
+import mdlaf.utils.MaterialDrawingUtils;
+
 import java.awt.*;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
@@ -149,6 +152,11 @@ public abstract class MaterialComponentField extends BasicTextFieldUI {
         }
 
         propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    @Override
+    protected void paintSafely(Graphics g) {
+        super.paintSafely(MaterialDrawingUtils.getAliasedGraphics(g));
     }
 
     protected void paintLine(Graphics graphics) {

--- a/src/main/java/mdlaf/components/textfield/MaterialTextFieldUI.java
+++ b/src/main/java/mdlaf/components/textfield/MaterialTextFieldUI.java
@@ -27,8 +27,6 @@ package mdlaf.components.textfield;
 import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 
-import mdlaf.utils.MaterialDrawingUtils;
-
 import java.awt.*;
 
 /**
@@ -98,9 +96,8 @@ public class MaterialTextFieldUI extends MaterialComponentField {
 
     @Override
     public void paintSafely(Graphics g) {
-        Graphics ag = MaterialDrawingUtils.getAliasedGraphics(g);
-        super.paintSafely(ag);
-        paintLine(ag);
-        changeColorOnFocus(ag);
+        super.paintSafely(g);
+        paintLine(g);
+        changeColorOnFocus(g);
     }
 }

--- a/src/main/java/mdlaf/components/textfield/MaterialTextFieldUI.java
+++ b/src/main/java/mdlaf/components/textfield/MaterialTextFieldUI.java
@@ -26,6 +26,9 @@ package mdlaf.components.textfield;
 
 import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
+
+import mdlaf.utils.MaterialDrawingUtils;
+
 import java.awt.*;
 
 /**
@@ -95,8 +98,9 @@ public class MaterialTextFieldUI extends MaterialComponentField {
 
     @Override
     public void paintSafely(Graphics g) {
-        super.paintSafely(g);
-        paintLine(g);
-        changeColorOnFocus(g);
+        Graphics ag = MaterialDrawingUtils.getAliasedGraphics(g);
+        super.paintSafely(ag);
+        paintLine(ag);
+        changeColorOnFocus(ag);
     }
 }

--- a/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
+++ b/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
@@ -54,7 +54,7 @@ public class MaterialDrawingUtils {
         hints.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_DEFAULT);
         hints.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
         //hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
-        hints.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+        hints.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
         hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         //hints.put(RenderingHints.KEY_TEXT_ANTIALIASING,	RenderingHints.VALUE_TEXT_ANTIALIAS_GASP);
 

--- a/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
+++ b/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
@@ -26,6 +26,7 @@ package mdlaf.utils;
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicGraphicsUtils;
 import java.awt.*;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -46,22 +47,23 @@ public class MaterialDrawingUtils {
     public static Graphics getAliasedGraphics(Graphics g) {
         Map<RenderingHints.Key, Object> hints = (Map<RenderingHints.Key, Object>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
 
-        if (hints != null) {
-            hints.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            hints.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_DEFAULT);
-            hints.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
-            //hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
-            hints.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-            hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            //hints.put(RenderingHints.KEY_TEXT_ANTIALIASING,	RenderingHints.VALUE_TEXT_ANTIALIAS_GASP);
-
-            Graphics2D g2d = (Graphics2D) g;
-            g2d.addRenderingHints(hints);
-            return g2d;
+        if (hints == null) {
+            hints = new HashMap<>();
         }
+        hints.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        hints.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_DEFAULT);
+        hints.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
+        //hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+        hints.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+        hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        //hints.put(RenderingHints.KEY_TEXT_ANTIALIASING,	RenderingHints.VALUE_TEXT_ANTIALIAS_GASP);
+
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.addRenderingHints(hints);
+        return g2d;
 
         //g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON));
-        return g;
+        //return g;
     }
 
     public static void drawCircle(Graphics g, int x, int y, int radius, Color color) {

--- a/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
+++ b/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
@@ -61,9 +61,6 @@ public class MaterialDrawingUtils {
         Graphics2D g2d = (Graphics2D) g;
         g2d.addRenderingHints(hints);
         return g2d;
-
-        //g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON));
-        //return g;
     }
 
     public static void drawCircle(Graphics g, int x, int y, int radius, Color color) {


### PR DESCRIPTION
Anti aliasing rendering hints can be applied even when system defaults are null.

Additionally, MaterialMenuUI and MaterialTextFieldUI now use anti aliased renders.