### PR TITLE
Anti aliased render for menus and text fields

### DIFF
--- a/src/main/java/mdlaf/components/menu/MaterialMenuUI.java
+++ b/src/main/java/mdlaf/components/menu/MaterialMenuUI.java
@@ -27,6 +27,9 @@ import javax.swing.*;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicMenuUI;
+
+import mdlaf.utils.MaterialDrawingUtils;
+
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -65,7 +68,7 @@ public class MaterialMenuUI extends BasicMenuUI {
 
 	@Override
 	public void paint (Graphics g, JComponent c) {
-		super.paint (g, c);
+		super.paint (MaterialDrawingUtils.getAliasedGraphics (g), c);
 	}
 
 	@Override

--- a/src/main/java/mdlaf/components/textfield/MaterialComponentField.java
+++ b/src/main/java/mdlaf/components/textfield/MaterialComponentField.java
@@ -27,6 +27,9 @@ package mdlaf.components.textfield;
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicTextFieldUI;
 import javax.swing.text.JTextComponent;
+
+import mdlaf.utils.MaterialDrawingUtils;
+
 import java.awt.*;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
@@ -149,6 +152,11 @@ public abstract class MaterialComponentField extends BasicTextFieldUI {
         }
 
         propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    @Override
+    protected void paintSafely(Graphics g) {
+        super.paintSafely(MaterialDrawingUtils.getAliasedGraphics(g));
     }
 
     protected void paintLine(Graphics graphics) {


### PR DESCRIPTION
As discussed in PR #154, the changes here allows `BasicMenuUI` and `BasicTextFieldUI` to use Material graphic hints.