### PR TITLE
Make swingx/MaterialTaskPaneUI optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ dependencies {
 
 ```
 
+### Excluding Swingx
+
+While swingx is a transitive dependency for Material-UI-Swing, it is not strictly required for it to work.
+Projects that wish to exclude it can use dependency exclusion on [Maven](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html)
+or [Gradle](https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:excluding-transitive-deps).
+
 ## Code Style
 > We live in a world where robots can drive a car, so we shouldn't just write code, we should write elegant code.
 

--- a/src/main/java/mdlaf/MaterialLookAndFeel.java
+++ b/src/main/java/mdlaf/MaterialLookAndFeel.java
@@ -113,7 +113,7 @@ public class MaterialLookAndFeel extends MetalLookAndFeel {
   private static final String separatorUI = MaterialSeparatorUI.class.getCanonicalName();
   private static final String fileChooserUI = MaterialFileChooserUI.class.getCanonicalName();
   private static final String toolTipUI = MaterialToolTipUI.class.getCanonicalName();
-  private static final String taskPaneUI = MaterialTaskPaneUI.class.getCanonicalName();
+  private static final String taskPaneUI;
   private static final String formattedTextFieldUI =
       MaterialFormattedTextFieldUI.class.getCanonicalName();
   private static final String listUI = MaterialListUI.class.getCanonicalName();
@@ -124,6 +124,16 @@ public class MaterialLookAndFeel extends MetalLookAndFeel {
   private static final String optionPaneUI = MaterialOptionPaneUI.class.getCanonicalName();
   private static final String colorChooserUI = MaterialColorChooser.class.getCanonicalName();
   private static final String splitPaneUI = MaterialSplitPaneUI.class.getCanonicalName();
+
+  static {
+    String taskPaneUIName = null;
+    try {
+      taskPaneUIName = MaterialTaskPaneUI.class.getCanonicalName();
+    } catch (NoClassDefFoundError ignored) {
+      // Swingx is not in the classpath
+    }
+    taskPaneUI = taskPaneUIName;
+  }
 
   public static void changeTheme(MaterialTheme theme) {
     if (theme == null) {
@@ -235,7 +245,9 @@ public class MaterialLookAndFeel extends MetalLookAndFeel {
     table.put("SplitPaneUI", splitPaneUI);
     table.put("ColorChooserUI", colorChooserUI);
     // java swingx
-    table.put("swingx/TaskPaneUI", taskPaneUI);
+    if (taskPaneUI != null) {
+      table.put("swingx/TaskPaneUI", taskPaneUI);
+    }
   }
 
   @Override


### PR DESCRIPTION
This change will gracefully catch NoClassDefFoundError in case swingx is not present in the classpath, allowing material ui to be used without it.

In the end, I've decided against making swingx compileOnly as it would require more changes than needed, consumers instead can exclude swingx if they desire.
For making MaterialTaskPaneUI optional, I decided to try-catch the class initialization instead of using a plain string with the class name to keep consistency with all other field declarations, but had to move it to a static block to do so.

Fixes #198