### PR TITLE
Fix JTextArea cursor misalignment on macOS with JDK8

### DIFF
--- a/src/main/java/mdlaf/utils/MaterialFontFactory.java
+++ b/src/main/java/mdlaf/utils/MaterialFontFactory.java
@@ -180,7 +180,13 @@ public class MaterialFontFactory {
         withPersonalSettings ? this.doOptimizingDimensionFont(this.defaultSize) : this.defaultSize;
     if (withPersonalSettings && fontSettings.isEmpty()) {
       fontSettings.put(TextAttribute.SIZE, size);
-      fontSettings.put(TextAttribute.KERNING, TextAttribute.KERNING_ON);
+      // Disable kerning on macOS with JDK8 to prevent cursor misalignment in text
+      // components (JTextArea, JTextField). Kerning combined with JDK8's integer-based
+      // caret positioning causes the cursor to drift ahead of the text.
+      // See: https://github.com/vincenzopalazzo/material-ui-swing/issues/142
+      if (!(Utils.isMacOS() && Utils.isJavaVersionUnderJava9())) {
+        fontSettings.put(TextAttribute.KERNING, TextAttribute.KERNING_ON);
+      }
     }
     try {
       Font font;

--- a/src/main/java/mdlaf/utils/Utils.java
+++ b/src/main/java/mdlaf/utils/Utils.java
@@ -30,5 +30,10 @@ public class Utils {
     return System.getProperty("java.version").startsWith("1.");
   }
 
+  public static boolean isMacOS() {
+    String osName = System.getProperty("os.name");
+    return osName != null && osName.toLowerCase().contains("mac");
+  }
+
   private Utils() {}
 }


### PR DESCRIPTION
## Summary
- JTextArea cursor drifts ~3 characters ahead of typed text on macOS with JDK8
- Root cause: `TextAttribute.KERNING_ON` applied globally causes JDK8's integer-based caret positioning to miscalculate glyph advances when combined with fractional metrics rendering
- Fix: conditionally disable kerning on macOS + JDK8 while keeping it enabled on all other platform/JDK combinations

## Test plan
- [ ] Verify cursor alignment in JTextArea on macOS with JDK8
- [ ] Verify kerning still works on JDK9+ (all platforms)
- [ ] Verify no visual regression on Linux/Windows

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)