### PR TITLE
Fix window dragging on HiDPI multi-monitor setups

### DIFF
--- a/src/main/java/mdlaf/components/titlepane/MaterialTitlePane.java
+++ b/src/main/java/mdlaf/components/titlepane/MaterialTitlePane.java
@@ -706,7 +706,7 @@ public class MaterialTitlePane extends JComponent {
     @Override
     public void mousePressed(MouseEvent e) {
       if (window == null) return; // should newer occur
-      dragOffset = SwingUtilities.convertPoint(MaterialTitlePane.this, e.getPoint(), window);
+      dragOffset = new Point(e.getXOnScreen() - window.getX(), e.getYOnScreen() - window.getY());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Window cursor loses sync when dragging across monitors with different DPI scaling (>100%)
- Root cause: drag offset computed in component-local coordinates (`SwingUtilities.convertPoint`) but used with screen coordinates (`getXOnScreen`) in the drag handler
- Fix: compute drag offset using screen coordinates consistently, matching the approach already used by `FlatWindowResizer`

Fixes #179

## Test plan
- [ ] Drag a window between two monitors with different DPI scaling — cursor should stay attached
- [ ] Drag from maximized state — window should restore and follow cursor correctly
- [ ] Normal single-monitor dragging still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>