### PR TITLE
Use scroll tab layout to prevent tab shifting and reordering

### DIFF
--- a/src/main/java/mdlaf/components/tabbedpane/MaterialTabbedPaneUI.java
+++ b/src/main/java/mdlaf/components/tabbedpane/MaterialTabbedPaneUI.java
@@ -69,6 +69,7 @@ public class MaterialTabbedPaneUI extends BasicTabbedPaneUI {
     super.installUI(c);
 
     tabPane.setOpaque(false);
+    tabPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
     this.foreground = new ColorUIResource(UIManager.getColor("TabbedPane.foreground"));
     this.selectedForeground =
         new ColorUIResource(UIManager.getColor("TabbedPane.selectionForeground"));


### PR DESCRIPTION
## Summary
- JTabbedPane with WRAP_TAB_LAYOUT causes tab row reordering when clicking tabs in non-adjacent rows and left-ward shifting when tabs are dynamically added
- Root cause: BasicTabbedPaneUI rotates rows to keep the selected tab adjacent to content area
- Fix: force SCROLL_TAB_LAYOUT in MaterialTabbedPaneUI.installUI(), which follows Material Design guidelines for scrollable tabs

Fixes #50

## Test plan
- [ ] CI passes
- [ ] Create a JTabbedPane with many tabs — tabs should scroll horizontally with arrow buttons instead of wrapping
- [ ] Dynamically add tabs — no shifting should occur
- [ ] Click tabs — no row reordering should occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)