### PR TITLE
Recompute font attributes when loading fonts

### DIFF
--- a/src/main/java/mdlaf/utils/MaterialFontFactory.java
+++ b/src/main/java/mdlaf/utils/MaterialFontFactory.java
@@ -41,8 +41,6 @@ import javax.swing.plaf.FontUIResource;
  */
 public class MaterialFontFactory {
 
-  private static final Map<TextAttribute, Object> fontSettings = new HashMap<>();
-
   public static final MaterialTypeFont REGULAR = MaterialTypeFont.REGULAR;
   public static final MaterialTypeFont BOLD = MaterialTypeFont.BOLD;
   public static final MaterialTypeFont ITALIC = MaterialTypeFont.ITALIC;
@@ -178,22 +176,24 @@ public class MaterialFontFactory {
   private FontUIResource loadFont(InputStream inputStream, boolean withPersonalSettings) {
     float size =
         withPersonalSettings ? this.doOptimizingDimensionFont(this.defaultSize) : this.defaultSize;
-    if (withPersonalSettings && fontSettings.isEmpty()) {
-      fontSettings.put(TextAttribute.SIZE, size);
-      fontSettings.put(TextAttribute.KERNING, TextAttribute.KERNING_ON);
-    }
     try {
-      Font font;
+      Font font = Font.createFont(Font.TRUETYPE_FONT, inputStream).deriveFont(size);
       if (withPersonalSettings) {
-        font = Font.createFont(Font.TRUETYPE_FONT, inputStream).deriveFont(fontSettings);
-        return new FontUIResource(font);
+        // Keep sizing outside the attribute map so SIZE cannot be accidentally cached and reused
+        // across font loads. That protects Java2D metrics when display scaling changes.
+        font = font.deriveFont(getFontSettings());
       }
-      font = Font.createFont(Font.TRUETYPE_FONT, inputStream).deriveFont(size);
       return new FontUIResource(font);
     } catch (IOException | FontFormatException e) {
       e.printStackTrace();
       throw new RuntimeException("Font " + inputStream.toString() + " wasn't loaded");
     }
+  }
+
+  private static Map<TextAttribute, Object> getFontSettings() {
+    Map<TextAttribute, Object> settings = new HashMap<>();
+    settings.put(TextAttribute.KERNING, TextAttribute.KERNING_ON);
+    return settings;
   }
 
   /**

--- a/src/test/java/unittest/MaterialFontFactoryTest.java
+++ b/src/test/java/unittest/MaterialFontFactoryTest.java
@@ -4,9 +4,11 @@ import static java.awt.GraphicsEnvironment.isHeadless;
 import static org.junit.Assume.assumeFalse;
 
 import java.awt.*;
+import java.lang.reflect.Field;
 import javax.swing.plaf.FontUIResource;
 import junit.framework.TestCase;
 import mdlaf.utils.MaterialFontFactory;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +26,11 @@ public class MaterialFontFactoryTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     assumeFalse("Font tests can't run in headless env.", isHeadless());
+  }
+
+  @After
+  public void resetDefaultSize() throws Exception {
+    setDefaultFontSize(MaterialFontFactory.getInstance(), 14f);
   }
 
   @Test
@@ -61,5 +68,27 @@ public class MaterialFontFactoryTest {
     TestCase.assertEquals(fontOne, fontTwo);
     TestCase.assertTrue(fontOne instanceof FontUIResource);
     TestCase.assertTrue(fontTwo instanceof FontUIResource);
+  }
+
+  @Test
+  public void testFontAttributesAreRecomputedForEachLoad() throws Exception {
+    MaterialFontFactory fontFactory = MaterialFontFactory.getInstance();
+
+    setDefaultFontSize(fontFactory, 18f);
+    Font largerFont =
+        fontFactory.getFontWithStream(getClass().getResourceAsStream(PATH + REGULAR_NAME));
+
+    setDefaultFontSize(fontFactory, 14f);
+    Font defaultFont =
+        fontFactory.getFontWithStream(getClass().getResourceAsStream(PATH + REGULAR_NAME));
+
+    TestCase.assertEquals(18f, largerFont.getSize2D());
+    TestCase.assertEquals(14f, defaultFont.getSize2D());
+  }
+
+  private void setDefaultFontSize(MaterialFontFactory fontFactory, float size) throws Exception {
+    Field defaultSize = MaterialFontFactory.class.getDeclaredField("defaultSize");
+    defaultSize.setAccessible(true);
+    defaultSize.set(fontFactory, size);
   }
 }


### PR DESCRIPTION
## Summary
- Font sizes could be fixed from the first font load because MaterialFontFactory reused a static TextAttribute map containing TextAttribute.SIZE.
- This PR fixes that SIZE-pinning precondition by deriving the font size for each load and using fresh per-load font attributes for kerning.
- It does not claim full end-to-end verification of the JMARS DemoFrame mixed-DPI behavior; cache invalidation for the normal L&F font path is tracked separately in #206.

## Test plan
- [x] javac --release 8 for Utils and MaterialFontFactory
- [x] Focused Java regression harness verifies font loads can change from 18pt back to 14pt
- [ ] ./gradlew test --tests unittest.MaterialFontFactoryTest (blocked locally: bundled Gradle/Groovy fails on Java 17 with Unsupported class file major version 61)
