### PR TITLE
fix: align Material text metrics across Retina displays

### DIFF
--- a/src/main/java/mdlaf/components/button/MaterialButtonUI.java
+++ b/src/main/java/mdlaf/components/button/MaterialButtonUI.java
@@ -66,6 +66,7 @@ public class MaterialButtonUI extends BasicButtonUI {
   @Override
   public void installUI(JComponent c) {
     super.installUI(c);
+    MaterialDrawingUtils.installTextRenderingHints(c);
 
     AbstractButton button = (AbstractButton) c;
     button.setOpaque(UIManager.getBoolean("Button.opaque"));
@@ -109,6 +110,7 @@ public class MaterialButtonUI extends BasicButtonUI {
 
   @Override
   public void uninstallUI(JComponent c) {
+    MaterialDrawingUtils.uninstallTextRenderingHints(c);
     super.uninstallUI(c);
 
     AbstractButton button = (AbstractButton) c;

--- a/src/main/java/mdlaf/components/label/MaterialLabelUI.java
+++ b/src/main/java/mdlaf/components/label/MaterialLabelUI.java
@@ -45,10 +45,12 @@ public class MaterialLabelUI extends BasicLabelUI {
   @Override
   public void installUI(JComponent c) {
     super.installUI(c);
+    MaterialDrawingUtils.installTextRenderingHints(c);
   }
 
   @Override
   public void uninstallUI(JComponent c) {
+    MaterialDrawingUtils.uninstallTextRenderingHints(c);
     super.uninstallUI(c);
   }
 

--- a/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
+++ b/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
@@ -29,6 +29,11 @@ import javax.swing.plaf.basic.BasicGraphicsUtils;
  * @author https://github.com/atarw
  */
 public class MaterialDrawingUtils {
+  private static final String OLD_FRACTIONAL_METRICS =
+      MaterialDrawingUtils.class.getName() + ".oldFractionalMetrics";
+  private static final String OLD_TEXT_ANTIALIASING =
+      MaterialDrawingUtils.class.getName() + ".oldTextAntialiasing";
+  private static final Object NO_CLIENT_PROPERTY = new Object();
 
   static {
     System.setProperty("awt.useSystemAAFontSettings", "on");
@@ -60,6 +65,58 @@ public class MaterialDrawingUtils {
     // g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING,
     // RenderingHints.VALUE_ANTIALIAS_ON));
     return g;
+  }
+
+  public static void installTextRenderingHints(JComponent c) {
+    // BasicLabelUI/BasicButtonUI measure through JComponent.getFontMetrics, which reads these
+    // RenderingHints keys from client properties. Keep layout metrics aligned with Material paint
+    // hints so a window laid out on 1x does not clip text when repainted on 2x.
+    installTextRenderingHint(
+        c,
+        RenderingHints.KEY_FRACTIONALMETRICS,
+        RenderingHints.VALUE_FRACTIONALMETRICS_ON,
+        OLD_FRACTIONAL_METRICS);
+    installTextRenderingHint(
+        c,
+        RenderingHints.KEY_TEXT_ANTIALIASING,
+        RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+        OLD_TEXT_ANTIALIASING);
+  }
+
+  public static void uninstallTextRenderingHints(JComponent c) {
+    uninstallTextRenderingHint(
+        c,
+        RenderingHints.KEY_FRACTIONALMETRICS,
+        RenderingHints.VALUE_FRACTIONALMETRICS_ON,
+        OLD_FRACTIONAL_METRICS);
+    uninstallTextRenderingHint(
+        c,
+        RenderingHints.KEY_TEXT_ANTIALIASING,
+        RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+        OLD_TEXT_ANTIALIASING);
+  }
+
+  private static void installTextRenderingHint(
+      JComponent c, RenderingHints.Key hintKey, Object hintValue, String oldValueKey) {
+    if (c.getClientProperty(oldValueKey) != null) {
+      return;
+    }
+    Object oldValue = c.getClientProperty(hintKey);
+    c.putClientProperty(oldValueKey, oldValue == null ? NO_CLIENT_PROPERTY : oldValue);
+    c.putClientProperty(hintKey, hintValue);
+  }
+
+  private static void uninstallTextRenderingHint(
+      JComponent c, RenderingHints.Key hintKey, Object installedValue, String oldValueKey) {
+    Object oldValue = c.getClientProperty(oldValueKey);
+    if (oldValue == null) {
+      return;
+    }
+    c.putClientProperty(oldValueKey, null);
+    if (c.getClientProperty(hintKey) != installedValue) {
+      return;
+    }
+    c.putClientProperty(hintKey, oldValue == NO_CLIENT_PROPERTY ? null : oldValue);
   }
 
   public static void drawCircle(Graphics g, int x, int y, int radius, Color color) {


### PR DESCRIPTION
## Summary

Supersedes #208 with a principled fix for the macOS 1x -> 2x Retina text truncation. Instead of removing fractional paint metrics or reinstalling the L&F, this installs Material text rendering hints as Swing client properties on labels and buttons so BasicLabelUI/BasicButtonUI layout uses the same fractional metrics policy as Material paint.

## Root cause

BasicLabelUI and BasicButtonUI measure through JComponent.getFontMetrics, which delegates to sun.swing.SwingUtilities2.getFontMetrics(JComponent, Font). SwingUtilities2 derives the FRC from the component GraphicsConfiguration and the component client properties RenderingHints.KEY_TEXT_ANTIALIASING and KEY_FRACTIONALMETRICS. Material paint was enabling fractional metrics on the Graphics, but the Swing layout path still used the default fractional metrics hint.

With Noto Sans Display 14 and text "Lat/Lon", the default integer-metrics path measures 47 px on a 1x transform and 48 px on a 2x transform. A window laid out on 1x can therefore carry a stale 47 px label width onto 2x, where BasicLabelUI remeasures 48 px and clips to "Lat/L...". With fractional metrics installed into the Swing layout path, 1x and 2x both measure 47 px and the stale-width 2x layout keeps "Lat/Lon" intact.

## Diagnostic numbers

Probe environment had built-in Retina 2x and external 1x displays:

- screen[0]: transform 2.0, bounds 1512x982
- screen[1]: transform 1.0, bounds 3440x1440

For "Lat/Lon" in Noto Sans Display Regular 14 with kerning on:

- 1x default layout width: 47 px
- 2x default layout width: 48 px
- 1x fractional layout width: 47 px
- 2x fractional layout width: 47 px
- 1x paint g.getFontMetrics with FM_ON: 47 px
- 2x paint g.getFontMetrics with FM_ON: 47 px
- 1x GlyphVector visual bounds with FM_ON: 44.8880 px
- 2x GlyphVector visual bounds with FM_ON: 44.8961 px
- font.getStringBounds with FM_ON: 47.2358 px at 1x, 47.2362 px at 2x

Hypothesis checks:

- Computing layout with a paint-matching fractional FRC fixes the truncation: stale 1x width on 2x lays out "Lat/Lon" instead of "Lat/L...".
- Disabling TextAttribute.KERNING_ON does not change the 47 -> 48 px default-metrics discrepancy.
- deriveFont(AffineTransform.getScaleInstance(1, 1)) does not change the 47 -> 48 px default-metrics discrepancy.

## Verification

- Simulated 1x and 2x GraphicsConfiguration transforms in a local probe on the actual dual-display Mac.
- Confirmed patched MaterialLabelUI preferred width stays 47 -> 47 px and patched MaterialButtonUI preferred width stays 91 -> 91 px.
- javac --release 8 targeted compile of the changed classes passed.
- git diff --check passed.

Gradle wrapper verification is blocked on this machine because the bundled Gradle/Groovy fails on JDK 17 before project evaluation with Unsupported class file major version 61.