### PR TITLE
build: support Java 17 (Gradle 7.6 + maven-publish)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: temurin
+        java-version: 17
+        cache: gradle
     - name: Veryfy Java Code Style
       run: ./gradlew verifyGoogleJavaFormat
     - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          distribution: temurin
+          java-version: 17
+          cache: gradle
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Veryfy Java Code Style
@@ -33,7 +29,7 @@ jobs:
           echo "${{secrets.SIGNING_KEY}}" > ~/.gradle/secring.gpg.b64
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
       - name: Publish package
-        run: ./gradlew uploadArchives -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) -PRELEASE_ENABLE=true
+        run: ./gradlew publish -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) -PRELEASE_ENABLE=true
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
@@ -42,7 +38,7 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
       - name: Build jar with dependencies
         run: ./gradlew jarWithDependencies
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: release-jars
           path: build/libs/

--- a/build.gradle
+++ b/build.gradle
@@ -11,18 +11,19 @@ buildscript {
 
 apply plugin: 'java-library'
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: "com.github.sherter.google-java-format"
+
+googleJavaFormat {
+    toolVersion = '1.15.0'
+}
+
 apply from: 'gradle/local-deploy.gradle'
 apply from: 'gradle/release.gradle'
 
 repositories {
-    jcenter()
-    flatDir {
-        dirs '/home/vincent/Github/DarkStackOverflowTheme/build/libs'
-        dirs '/home/vincent/Github/jiconfont-google_material_design_icons/target'
-    }
+    mavenCentral()
 }
 
 dependencies {
@@ -30,15 +31,15 @@ dependencies {
     implementation 'com.github.jiconfont:jiconfont-swing:1.0.1'
 
     //Slf4j configuration
-    testCompile 'ch.qos.logback:logback-classic:1.2.3'
-    testCompile 'ch.qos.logback:logback-core:1.2.3'
-    testCompile 'org.slf4j:slf4j-api:1.7.25'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-core:1.2.3'
+    testImplementation 'org.slf4j:slf4j-api:1.7.25'
     // Use JUnit test framework
-    testCompile 'junit:junit:4.12'
-    testCompile group: 'org.assertj', name: 'assertj-swing-junit', version: '3.9.2'
+    testImplementation 'junit:junit:4.12'
+    testImplementation group: 'org.assertj', name: 'assertj-swing-junit', version: '3.9.2'
     // Testing dependencies
-    testCompile 'io.github.material-ui-swing:DarkStackOverflowTheme:0.0.1-rc2'
-    testCompile group: 'com.toedter', name: 'jcalendar', version: '1.4'
+    testImplementation 'io.github.material-ui-swing:DarkStackOverflowTheme:0.0.1-rc2'
+    testImplementation group: 'com.toedter', name: 'jcalendar', version: '1.4'
 }
 
 allprojects {
@@ -78,5 +79,6 @@ task runDemo(type: Exec) {
     commandLine "java", "-classpath", sourceSets.test.runtimeClasspath.getAsPath(), 'integration.gui.mock.DemoGUITest'
 }
 
-uploadArchives.onlyIf { property('RELEASE_ENABLE') == 'true'}
-signArchives.onlyIf { property('RELEASE_ENABLE') == 'true'}
+tasks.withType(Javadoc).configureEach {
+    options.addStringOption('Xdoclint:none', '-quiet')
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,9 @@ MODULE_NAME=io.github.vincenzopalazzo.materialuiswing
 RELEASE_ENABLE=true
 org.gradle.caching=true
 
+# Required by google-java-format on JDK 16+ to access compiler internals.
+org.gradle.jvmargs=-Xmx1g --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+
 #Information abaut the maven repository
 #signing.keyId=KYE
 #signing.password=PASS

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,99 +1,78 @@
-// Inside this file was described the configuration used to upload the new release on maven
-task javadocJar(type: Jar) {
-	archiveClassifier = 'javadoc'
-	from javadoc
+// Configuration used to publish a new release to Maven Central via the
+// `maven-publish` plugin. Signing and the OSSRH upload step are gated on
+// the RELEASE_ENABLE property so local builds work without GPG keys.
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
-task sourcesJar(type: Jar) {
-	archiveClassifier = 'sources'
-	from sourceSets.main.allSource
-}
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            groupId = GROUP_ID
+            artifactId = ARTIFACT_ID
+            version = VERSION
 
-artifacts {
-	archives javadocJar, sourcesJar
+            pom {
+                name = ARTIFACT_ID
+                description = ARTIFACT_ID
+                url = 'https://github.com/vincenzopalazzo/material-ui-swing'
+                inceptionYear = '2020'
+
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://github.com/vincenzopalazzo/material-ui-swing/blob/master/LICENSE'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'vincenzopalazzo'
+                        name = 'Vincenzo Palazzo'
+                        email = 'vincenzopalazzodev@gmail.com'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:https://github.com/vincenzopalazzo/material-ui-swing.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/vincenzopalazzo/material-ui-swing.git'
+                    url = 'https://github.com/vincenzopalazzo/material-ui-swing'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'OSSRH'
+            def releasesUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            def snapshotsUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
+            url = (VERSION as String).endsWith('SNAPSHOT') ? snapshotsUrl : releasesUrl
+            credentials {
+                username = System.getenv('MAVEN_USERNAME')
+                password = System.getenv('MAVEN_PASSWORD')
+            }
+        }
+    }
 }
 
 signing {
-	sign configurations.archives
+    required {
+        Boolean.parseBoolean(findProperty('RELEASE_ENABLE')?.toString() ?: 'false') &&
+            findProperty('signing.keyId') != null
+    }
+    sign publishing.publications.mavenJava
 }
 
-uploadArchives {
-	repositories {
-		mavenDeployer {
-			beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-			repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
-				authentication(userName: System.getenv("MAVEN_USERNAME"), password: System.getenv("MAVEN_PASSWORD"))
-			}
-
-			snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
-				authentication(userName: System.getenv("MAVEN_USERNAME"), password: System.getenv("MAVEN_PASSWORD"))
-			}
-
-			pom.project {
-				name archivesBaseName
-				packaging 'jar'
-				// optionally artifactId can be defined here
-				print('Archive base name: ' + archivesBaseName)
-				groupId GROUP_ID
-				artifactId ARTIFACT_ID
-				version VERSION
-				description archivesBaseName
-				url 'https://github.com/vincenzopalazzo/material-ui-swing'
-
-				scm {
-					connection 'https://github.com/vincenzopalazzo/material-ui-swing'
-					developerConnection 'https://github.com/vincenzopalazzo/material-ui-swing.git'
-					url 'https://github.com/vincenzopalazzo/material-ui-swing'
-				}
-
-				licenses {
-					license {
-						name 'MIT'
-						url 'https://github.com/vincenzopalazzo/material-ui-swing/blob/masternow/LICENSE'
-					}
-				}
-
-				developers {
-					developer {
-						id 'vincenzopalazzo'
-						name 'Vincenzo Palazzo'
-						email 'vincenzopalazzodev@gmail.com'
-					}
-				}
-			}
-		}
-	}
-}
-
-task createPom {
-	pom {
-		project {
-			groupId GROUP_ID
-			artifactId ARTIFACT_ID
-			version VERSION
-
-			properties {
-				project {
-					build {
-						sourceEncoding 'UTF-8'
-					}
-				}
-				maven {
-					compiler {
-						source '1.8'
-						target '1.8'
-					}
-				}
-			}
-			inceptionYear '2020'
-			licenses {
-				license {
-					name 'MIT'
-					url 'https://github.com/vincenzopalazzo/material-ui-swing/blob/masternow/LICENSE'
-					distribution 'repo'
-				}
-			}
-		}
-	}.writeTo("pom.xml")
+// Match the legacy `uploadArchives.onlyIf { RELEASE_ENABLE == 'true' }` behavior
+// so maintainers following docs/dev/MAINTAINERS.md (which instructs them to set
+// RELEASE_ENABLE=false locally) don't accidentally upload to OSSRH if Maven
+// credentials happen to be present in the environment.
+tasks.withType(PublishToMavenRepository).configureEach {
+    onlyIf {
+        Boolean.parseBoolean(findProperty('RELEASE_ENABLE')?.toString() ?: 'false')
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip

--- a/src/main/java/mdlaf/MaterialLookAndFeelInfo.java
+++ b/src/main/java/mdlaf/MaterialLookAndFeelInfo.java
@@ -23,7 +23,9 @@ package mdlaf;
 
 import javax.swing.*;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialLookAndFeelInfo extends UIManager.LookAndFeelInfo {
 
   public MaterialLookAndFeelInfo(String name, String className) {

--- a/src/main/java/mdlaf/components/button/MaterialButtonUI.java
+++ b/src/main/java/mdlaf/components/button/MaterialButtonUI.java
@@ -32,7 +32,9 @@ import mdlaf.animation.MaterialMouseHover;
 import mdlaf.animation.MaterialUIMovement;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialButtonUI extends BasicButtonUI {
 
   public static ComponentUI createUI(final JComponent c) {

--- a/src/main/java/mdlaf/components/checkbox/MaterialCheckBoxUI.java
+++ b/src/main/java/mdlaf/components/checkbox/MaterialCheckBoxUI.java
@@ -30,7 +30,9 @@ import javax.swing.plaf.basic.BasicCheckBoxUI;
 import mdlaf.animation.MaterialMouseHover;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialCheckBoxUI extends BasicCheckBoxUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/components/checkboxmenuitem/MaterialCheckBoxMenuItemUI.java
+++ b/src/main/java/mdlaf/components/checkboxmenuitem/MaterialCheckBoxMenuItemUI.java
@@ -26,7 +26,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicCheckBoxMenuItemUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialCheckBoxMenuItemUI extends BasicCheckBoxMenuItemUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/components/colorchooser/MaterialColorChooser.java
+++ b/src/main/java/mdlaf/components/colorchooser/MaterialColorChooser.java
@@ -25,7 +25,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicColorChooserUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialColorChooser extends BasicColorChooserUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/combobox/MaterialComboBoxEditor.java
+++ b/src/main/java/mdlaf/components/combobox/MaterialComboBoxEditor.java
@@ -25,7 +25,9 @@ import java.awt.*;
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicComboBoxEditor;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialComboBoxEditor extends BasicComboBoxEditor {
 
   @Override

--- a/src/main/java/mdlaf/components/editorpane/MaterialEditorPaneUI.java
+++ b/src/main/java/mdlaf/components/editorpane/MaterialEditorPaneUI.java
@@ -25,7 +25,9 @@ import javax.swing.JComponent;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicEditorPaneUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialEditorPaneUI extends BasicEditorPaneUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/components/formattertextfield/MaterialFormattedTextFieldUI.java
+++ b/src/main/java/mdlaf/components/formattertextfield/MaterialFormattedTextFieldUI.java
@@ -27,7 +27,9 @@ import javax.swing.plaf.ComponentUI;
 import mdlaf.components.textfield.MaterialComponentField;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialFormattedTextFieldUI extends MaterialComponentField {
 
   protected static final String ProprietyPrefix = "FormattedTextField";

--- a/src/main/java/mdlaf/components/internalframe/MaterialInternalFrameTitlePane.java
+++ b/src/main/java/mdlaf/components/internalframe/MaterialInternalFrameTitlePane.java
@@ -26,7 +26,9 @@ import javax.swing.*;
 import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
 import mdlaf.components.button.MaterialButtonUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialInternalFrameTitlePane extends BasicInternalFrameTitlePane {
 
   public MaterialInternalFrameTitlePane(JInternalFrame f) {

--- a/src/main/java/mdlaf/components/internalframe/MaterialInternalFrameUI.java
+++ b/src/main/java/mdlaf/components/internalframe/MaterialInternalFrameUI.java
@@ -25,7 +25,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicInternalFrameUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialInternalFrameUI extends BasicInternalFrameUI {
 
   public MaterialInternalFrameUI(JInternalFrame b) {

--- a/src/main/java/mdlaf/components/list/MaterialListCellRenderer.java
+++ b/src/main/java/mdlaf/components/list/MaterialListCellRenderer.java
@@ -24,7 +24,9 @@ package mdlaf.components.list;
 import java.awt.*;
 import javax.swing.*;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialListCellRenderer extends DefaultListCellRenderer {
 
   @Override

--- a/src/main/java/mdlaf/components/list/MaterialListUI.java
+++ b/src/main/java/mdlaf/components/list/MaterialListUI.java
@@ -25,7 +25,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicListUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialListUI extends BasicListUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/menu/MaterialMenuArrowIcon.java
+++ b/src/main/java/mdlaf/components/menu/MaterialMenuArrowIcon.java
@@ -23,7 +23,9 @@ package mdlaf.components.menu;
 import java.awt.*;
 import javax.swing.*;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialMenuArrowIcon implements Icon {
   @Override
   public void paintIcon(Component c, Graphics g, int x, int y) {

--- a/src/main/java/mdlaf/components/optionpane/MaterialOptionPaneUI.java
+++ b/src/main/java/mdlaf/components/optionpane/MaterialOptionPaneUI.java
@@ -29,7 +29,9 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicOptionPaneUI;
 import mdlaf.utils.MaterialImageFactory;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialOptionPaneUI extends BasicOptionPaneUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/progressbar/MaterialProgressBarUI.java
+++ b/src/main/java/mdlaf/components/progressbar/MaterialProgressBarUI.java
@@ -25,7 +25,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicProgressBarUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialProgressBarUI extends BasicProgressBarUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/components/radiobuttonmenuitem/MaterialRadioButtonMenuItemUI.java
+++ b/src/main/java/mdlaf/components/radiobuttonmenuitem/MaterialRadioButtonMenuItemUI.java
@@ -27,7 +27,9 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicRadioButtonMenuItemUI;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialRadioButtonMenuItemUI extends BasicRadioButtonMenuItemUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/components/separator/MaterialSeparatorUI.java
+++ b/src/main/java/mdlaf/components/separator/MaterialSeparatorUI.java
@@ -26,7 +26,9 @@ import javax.swing.JComponent;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicSeparatorUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialSeparatorUI extends BasicSeparatorUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/components/splitpane/MaterialSplitPaneUI.java
+++ b/src/main/java/mdlaf/components/splitpane/MaterialSplitPaneUI.java
@@ -28,7 +28,9 @@ import javax.swing.plaf.basic.BasicSplitPaneDivider;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
 import javax.swing.plaf.metal.MetalSplitPaneUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialSplitPaneUI extends MetalSplitPaneUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/tabbedpane/MaterialTabbedPaneUI.java
+++ b/src/main/java/mdlaf/components/tabbedpane/MaterialTabbedPaneUI.java
@@ -35,7 +35,9 @@ import mdlaf.animation.MaterialMouseHover;
 import mdlaf.components.button.MaterialButtonUI;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTabbedPaneUI extends BasicTabbedPaneUI {
 
   public static ComponentUI createUI(JComponent c) {
@@ -419,7 +421,9 @@ public class MaterialTabbedPaneUI extends BasicTabbedPaneUI {
     return new ArrowButtonTabbedPane(direction);
   }
 
-  /** @deprecated remove this implementation inside the version 1.2 of the library. */
+  /**
+   * @deprecated remove this implementation inside the version 1.2 of the library.
+   */
   @Deprecated
   protected class MaterialTabbedPaneLayout extends BasicTabbedPaneUI.TabbedPaneLayout {
 

--- a/src/main/java/mdlaf/components/table/MaterialTableCellRendererCheckBox.java
+++ b/src/main/java/mdlaf/components/table/MaterialTableCellRendererCheckBox.java
@@ -25,7 +25,9 @@ import java.awt.*;
 import javax.swing.*;
 import javax.swing.table.TableCellRenderer;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 class MaterialTableCellRendererCheckBox extends JCheckBox implements TableCellRenderer {
 
   protected Icon unchecked = UIManager.getIcon("Table[CheckBox].unchecked");

--- a/src/main/java/mdlaf/components/taskpane/MaterialTaskPaneUI.java
+++ b/src/main/java/mdlaf/components/taskpane/MaterialTaskPaneUI.java
@@ -28,7 +28,9 @@ import javax.swing.plaf.ComponentUI;
 import org.jdesktop.swingx.JXTaskPane;
 import org.jdesktop.swingx.plaf.basic.BasicTaskPaneUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTaskPaneUI extends BasicTaskPaneUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/textarea/MaterialTextAreaUI.java
+++ b/src/main/java/mdlaf/components/textarea/MaterialTextAreaUI.java
@@ -26,7 +26,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTextAreaUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTextAreaUI extends BasicTextAreaUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/textfield/MaterialComponentField.java
+++ b/src/main/java/mdlaf/components/textfield/MaterialComponentField.java
@@ -34,7 +34,9 @@ import javax.swing.*;
 import javax.swing.plaf.basic.BasicTextFieldUI;
 import javax.swing.text.JTextComponent;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public abstract class MaterialComponentField extends BasicTextFieldUI {
 
   protected static final String PROPERTY_LINE_COLOR = "lineColor";

--- a/src/main/java/mdlaf/components/textpane/MaterialTextPaneUI.java
+++ b/src/main/java/mdlaf/components/textpane/MaterialTextPaneUI.java
@@ -25,7 +25,9 @@ import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTextPaneUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTextPaneUI extends BasicTextPaneUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/main/java/mdlaf/components/tree/MaterialTreeCellEditor.java
+++ b/src/main/java/mdlaf/components/tree/MaterialTreeCellEditor.java
@@ -30,7 +30,9 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeCellEditor;
 import mdlaf.components.textfield.MaterialTextFieldUI;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTreeCellEditor extends DefaultTreeCellEditor {
 
   private JTextField textField;

--- a/src/main/java/mdlaf/components/tree/MaterialTreeCellRenderer.java
+++ b/src/main/java/mdlaf/components/tree/MaterialTreeCellRenderer.java
@@ -24,7 +24,9 @@ import java.awt.*;
 import javax.swing.*;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTreeCellRenderer extends DefaultTreeCellRenderer {
 
   protected Color foreground;

--- a/src/main/java/mdlaf/components/tree/MaterialTreeUI.java
+++ b/src/main/java/mdlaf/components/tree/MaterialTreeUI.java
@@ -28,7 +28,9 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeCellEditor;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTreeUI extends BasicTreeUI {
 
   public static ComponentUI createUI(JComponent c) {

--- a/src/main/java/mdlaf/shadows/RoundedCornerBorder.java
+++ b/src/main/java/mdlaf/shadows/RoundedCornerBorder.java
@@ -29,7 +29,9 @@ import javax.swing.border.AbstractBorder;
 import mdlaf.utils.MaterialColors;
 import mdlaf.utils.MaterialDrawingUtils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class RoundedCornerBorder extends AbstractBorder {
 
   protected int arch = 12; // default value

--- a/src/main/java/mdlaf/themes/AbstractMaterialTheme.java
+++ b/src/main/java/mdlaf/themes/AbstractMaterialTheme.java
@@ -32,7 +32,9 @@ import mdlaf.utils.MaterialFontFactory;
 import mdlaf.utils.MaterialImageFactory;
 import mdlaf.utils.icons.MaterialIconFont;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public abstract class AbstractMaterialTheme implements MaterialTheme {
 
   protected ColorUIResource backgroundPrimary;

--- a/src/main/java/mdlaf/themes/JMarsDarkTheme.java
+++ b/src/main/java/mdlaf/themes/JMarsDarkTheme.java
@@ -30,7 +30,9 @@ import mdlaf.utils.MaterialColors;
 import mdlaf.utils.MaterialImageFactory;
 import mdlaf.utils.icons.MaterialIconFont;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class JMarsDarkTheme extends AbstractMaterialTheme {
 
   @Override

--- a/src/main/java/mdlaf/themes/MaterialTheme.java
+++ b/src/main/java/mdlaf/themes/MaterialTheme.java
@@ -26,7 +26,9 @@ package mdlaf.themes;
 import javax.swing.*;
 import javax.swing.plaf.*;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 @SuppressWarnings("all")
 public interface MaterialTheme {
 

--- a/src/main/java/mdlaf/themes/exceptions/MaterialChangeThemeException.java
+++ b/src/main/java/mdlaf/themes/exceptions/MaterialChangeThemeException.java
@@ -23,7 +23,9 @@
  */
 package mdlaf.themes.exceptions;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialChangeThemeException extends RuntimeException {
 
   public MaterialChangeThemeException() {

--- a/src/main/java/mdlaf/utils/MaterialImageFactory.java
+++ b/src/main/java/mdlaf/utils/MaterialImageFactory.java
@@ -37,7 +37,9 @@ import jiconfont.swing.IconFontSwing;
 import mdlaf.utils.icons.IMaterialIconCode;
 import mdlaf.utils.icons.MaterialIconFont;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialImageFactory {
 
   static {

--- a/src/main/java/mdlaf/utils/MaterialManagerListener.java
+++ b/src/main/java/mdlaf/utils/MaterialManagerListener.java
@@ -27,7 +27,9 @@ import java.awt.event.MouseListener;
 import javax.swing.*;
 import mdlaf.animation.MaterialUITimer;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialManagerListener {
   /*
    * Look this if you would change this function

--- a/src/main/java/mdlaf/utils/Utils.java
+++ b/src/main/java/mdlaf/utils/Utils.java
@@ -23,7 +23,9 @@
  */
 package mdlaf.utils;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class Utils {
 
   public static boolean isJavaVersionUnderJava9() {

--- a/src/main/java/mdlaf/utils/WrapperSwingUtilities.java
+++ b/src/main/java/mdlaf/utils/WrapperSwingUtilities.java
@@ -29,7 +29,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import javax.swing.*;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class WrapperSwingUtilities {
 
   private static WrapperSwingUtilities SINGLETON;

--- a/src/main/java/mdlaf/utils/icons/MaterialIconFont.java
+++ b/src/main/java/mdlaf/utils/icons/MaterialIconFont.java
@@ -27,7 +27,9 @@ import java.io.InputStream;
 import jiconfont.IconFont;
 import mdlaf.utils.MaterialFontFactory;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public enum MaterialIconFont implements IMaterialIconCode {
 
   // New icon not supported inside the official repository

--- a/src/test/java/integration/gui/mock/DemoGUITest.java
+++ b/src/test/java/integration/gui/mock/DemoGUITest.java
@@ -44,7 +44,9 @@ import mdlaf.utils.MaterialColors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class DemoGUITest extends JFrame {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DemoGUITest.class);

--- a/src/test/java/integration/gui/mock/component/ContainerAction.java
+++ b/src/test/java/integration/gui/mock/component/ContainerAction.java
@@ -34,7 +34,9 @@ import mdlaf.themes.JMarsDarkTheme;
 import mdlaf.themes.MaterialLiteTheme;
 import mdlaf.themes.MaterialOceanicTheme;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class ContainerAction {
 
   private Action enableButtonDisabled = new ActionEnableButtonDisabled();

--- a/src/test/java/integration/gui/mock/component/CustomIconButtonUI.java
+++ b/src/test/java/integration/gui/mock/component/CustomIconButtonUI.java
@@ -26,7 +26,9 @@ import javax.swing.*;
 import mdlaf.components.button.MaterialButtonUI;
 import mdlaf.utils.MaterialColors;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class CustomIconButtonUI extends MaterialButtonUI {
 
   @Override

--- a/src/test/java/integration/gui/mock/component/DemoPanelWithTabbedPane.java
+++ b/src/test/java/integration/gui/mock/component/DemoPanelWithTabbedPane.java
@@ -4,7 +4,9 @@ import java.awt.*;
 import javax.swing.*;
 import mdlaf.utils.MaterialColors;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class DemoPanelWithTabbedPane extends JPanel {
 
   protected JTabbedPane tabbedPane;

--- a/src/test/java/integration/gui/mock/component/JButtonNoMouseHoverNative.java
+++ b/src/test/java/integration/gui/mock/component/JButtonNoMouseHoverNative.java
@@ -28,7 +28,9 @@ import mdlaf.animation.MaterialUIMovement;
 import mdlaf.components.button.MaterialButtonUI;
 import mdlaf.utils.MaterialColors;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class JButtonNoMouseHoverNative extends JButton {
 
   public JButtonNoMouseHoverNative() {}

--- a/src/test/java/integration/gui/mock/component/PersonalButtonUI.java
+++ b/src/test/java/integration/gui/mock/component/PersonalButtonUI.java
@@ -6,7 +6,9 @@ import javax.swing.plaf.ComponentUI;
 import mdlaf.components.button.MaterialButtonUI;
 import mdlaf.utils.MaterialColors;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class PersonalButtonUI extends MaterialButtonUI {
 
   @SuppressWarnings({"MethodOverridesStaticMethodOfSuperclass", "UnusedDeclaration"})

--- a/src/test/java/integration/gui/mock/component/PersonalToggleButtonTheme.java
+++ b/src/test/java/integration/gui/mock/component/PersonalToggleButtonTheme.java
@@ -26,7 +26,9 @@ package integration.gui.mock.component;
 import javax.swing.*;
 import mdlaf.themes.MaterialLiteTheme;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class PersonalToggleButtonTheme extends MaterialLiteTheme {
 
   public PersonalToggleButtonTheme() {

--- a/src/test/java/integration/gui/mock/component/TableModelSecondPanel.java
+++ b/src/test/java/integration/gui/mock/component/TableModelSecondPanel.java
@@ -27,7 +27,9 @@ import java.io.File;
 import java.util.Date;
 import javax.swing.table.AbstractTableModel;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class TableModelSecondPanel extends AbstractTableModel {
 
   protected File dir;

--- a/src/test/java/integration/gui/test/AbstractTestGUI.java
+++ b/src/test/java/integration/gui/test/AbstractTestGUI.java
@@ -38,7 +38,9 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public abstract class AbstractTestGUI extends AssertJSwingTestCaseTemplate {
 
   protected FrameFixture frame;

--- a/src/test/java/integration/gui/test/MaterialButtonTest.java
+++ b/src/test/java/integration/gui/test/MaterialButtonTest.java
@@ -27,7 +27,9 @@ import mdlaf.utils.MaterialColors;
 import org.assertj.swing.fixture.JButtonFixture;
 import org.junit.Test;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialButtonTest extends AbstractTestGUI {
 
   @Test

--- a/src/test/java/integration/gui/test/MaterialFocusedButtonTest.java
+++ b/src/test/java/integration/gui/test/MaterialFocusedButtonTest.java
@@ -27,7 +27,9 @@ import javax.swing.*;
 import org.assertj.swing.fixture.JButtonFixture;
 import org.junit.Test;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialFocusedButtonTest extends AbstractTestGUI {
 
   @Override

--- a/src/test/java/integration/gui/test/MaterialPasswordFieldTest.java
+++ b/src/test/java/integration/gui/test/MaterialPasswordFieldTest.java
@@ -30,7 +30,9 @@ import org.assertj.swing.fixture.JTextComponentFixture;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialPasswordFieldTest extends AbstractTestGUI {
 
   /*

--- a/src/test/java/integration/gui/test/MaterialTextFieldTest.java
+++ b/src/test/java/integration/gui/test/MaterialTextFieldTest.java
@@ -30,7 +30,9 @@ import org.assertj.swing.fixture.JTextComponentFixture;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** @author https://github.com/vincenzopalazzo */
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
 public class MaterialTextFieldTest extends AbstractTestGUI {
 
   /*


### PR DESCRIPTION
## Summary

Makes the project build on Java 17. Triggered by Zoya hitting the same wall on her Eclipse workspace and sharing a minimal patch on Slack — this PR builds on her diff but also ports `release.gradle` properly so Maven Central publishing keeps working.

- Bump Gradle wrapper `6.4.1` → `7.6.4` (Gradle 6 doesn't run on Java 17)
- Replace legacy `maven` plugin with `maven-publish`; rewrite [gradle/release.gradle](gradle/release.gradle) to use `publishing { publications { mavenJava ... } }` instead of the removed `uploadArchives { mavenDeployer { ... } }`
- `testCompile` → `testImplementation` (×7) — `testCompile` was removed in Gradle 7
- `jcenter()` → `mavenCentral()`; drop the dead `/home/vincent/...` flatDir paths (the same artifacts already resolve from Central)
- Pin `googleJavaFormat { toolVersion = '1.15.0' }` — the plugin's default 1.7 cannot parse Java 17 sources; reformat the codebase with 1.15.0 (mostly javadoc reflow)
- Add `--add-exports` JVM args in `gradle.properties` so google-java-format can reach JDK compiler internals on Java 16+
- Disable `-Xdoclint` on `Javadoc` tasks — Java 17's stricter doclint treats pre-existing `&` characters in comments as malformed HTML entities
- Gate signing on `RELEASE_ENABLE` AND a configured `signing.keyId`, so local builds skip signing instead of failing with "no configured signatory"
- CI: bump `actions/checkout` and `actions/setup-java` to v4, switch JDK to Temurin 17, replace `./gradlew uploadArchives` with `./gradlew publish`

The reformat is a separate commit (50 files, mostly javadoc reflow) so reviewers can skip it.

## Test plan

- [x] `./gradlew --version` reports Gradle 7.6.4 on JVM 17
- [x] `./gradlew build -x test` succeeds locally
- [x] `./gradlew verifyGoogleJavaFormat` passes
- [x] `./gradlew publishToMavenLocal` produces `material-ui-swing-1.1.4.jar`, `-sources.jar`, `-javadoc.jar`, and a clean POM under `~/.m2/repository/io/github/vincenzopalazzo/material-ui-swing/1.1.4/`
- [x] Generated POM has all Maven Central required fields (groupId, artifactId, name, description, url, licenses, developers, scm)
- [x] Signing is correctly skipped locally when no GPG key is present
- [ ] Confirm GitHub Actions `build` workflow passes on PR (Java 17 / setup-java@v4)
- [ ] Confirm `release` workflow runs end-to-end on next tagged release (`./gradlew publish` replaces `./gradlew uploadArchives`)

## Notes for review

- Tests are skipped (`-x test`) because the existing test suite is GUI-driven (`assertj-swing-junit`) and the CI already only runs `compileJava` rather than `build`.
- `JDK_VERSION=1.8` in `gradle.properties` is unchanged — bytecode target stays Java 8 so the published artifact remains compatible with Java 8 consumers, even though the build itself now requires Java 17.
- google-java-format-gradle-plugin 0.9 is unmaintained since 2020. Pinning the formatter version is a workaround; longer-term we should consider switching to spotless. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)